### PR TITLE
Append the field path to errors in `.toPrimative`

### DIFF
--- a/lib/shred.js
+++ b/lib/shred.js
@@ -125,10 +125,14 @@ function shredRecordInternal(fields, record, data, rlvl, dlvl) {
             rlvl_i,
             field.dLevelMax);
       } else {
-        data[field.path].values.push(parquet_types.toPrimitive(fieldType, values[i]));
-        data[field.path].rlevels.push(rlvl_i);
-        data[field.path].dlevels.push(field.dLevelMax);
-        data[field.path].count += 1;
+        try {
+          data[field.path].values.push(parquet_types.toPrimitive(fieldType, values[i]));
+          data[field.path].rlevels.push(rlvl_i);
+          data[field.path].dlevels.push(field.dLevelMax);
+          data[field.path].count += 1;
+        } catch(e) {
+          throw `${e.message || e} for field ${field.path}`;
+        }
       }
     }
   }


### PR DESCRIPTION
To make debugging the schema easier