### PR TITLE
Switch `async` to traditional promises

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -231,6 +231,7 @@ class ParquetReader {
  * This class is intended for advanced/internal users; if you just want to retrieve
  * rows from a parquet file use the ParquetReader instead
  */
+let ParquetEnvelopeReaderIdCounter = 0;
 class ParquetEnvelopeReader {
 
   static async openFile(filePath, options) {
@@ -305,6 +306,7 @@ class ParquetEnvelopeReader {
   constructor(readFn, closeFn, fileSize, options) {
     options = options || {};
     this.readFn = readFn;
+    this.id = ++ParquetEnvelopeReaderIdCounter;
     this.close = closeFn;
     this.fileSize = fileSize;
     this.default_dictionary_size = options.default_dictionary_size || 10000000;
@@ -314,16 +316,16 @@ class ParquetEnvelopeReader {
     }
   }
 
-  async read(offset, length) {
-    return await this.readFn(offset, length);
+  read(offset, length) {
+    return this.readFn(offset, length);
   }
 
-  async readHeader() {
-    let buf = await this.read(0, PARQUET_MAGIC.length);
-
-    if (buf.toString() != PARQUET_MAGIC) {
-      throw 'not valid parquet file'
-    }
+  readHeader() {
+    return this.read(0, PARQUET_MAGIC.length).then(buf => {
+      if (buf.toString() != PARQUET_MAGIC) {
+        throw 'not valid parquet file'
+      }
+    });
   }
 
   // Helper function to get the column object for a particular path and row_group
@@ -347,48 +349,56 @@ class ParquetEnvelopeReader {
     return column;
   }
 
-  async readOffsetIndex(path, row_group) {
+  readOffsetIndex(path, row_group) {
     let column = this.getColumn(path, row_group);
-    let offset_index = new parquet_thrift.OffsetIndex();
-    parquet_util.decodeThrift(offset_index,await this.read(+column.offset_index_offset, column.offset_index_length));
-    Object.defineProperty(offset_index,'column', {value: column, enumerable: false});
-    return offset_index;
+    return this.read(+column.offset_index_offset, column.offset_index_length).then(data => {
+      let offset_index = new parquet_thrift.OffsetIndex();
+      parquet_util.decodeThrift(offset_index, data);
+      offset_index.column = column;
+      //Object.defineProperty(offset_index,'column', {value: column, enumerable: false});
+      return offset_index;
+    });
   }
 
-  async readColumnIndex(path, row_group) {
+  readColumnIndex(path, row_group) {
     let column = this.getColumn(path, row_group);
-    let column_index = new parquet_thrift.ColumnIndex();
     if (!column.column_index_offset) {
-      throw new Error('No Column Index');
-    }
-    parquet_util.decodeThrift(column_index,await this.read(+column.column_index_offset, column.column_index_length));
-    Object.defineProperty(column_index, 'column', { value: column });
-
-    // decode the statistics values
-    const field = this.schema.findField(column.meta_data.path_in_schema);
-    if (column_index.max_values) {
-      column_index.max_values = column_index.max_values.map(max_value => decodeStatisticsValue(max_value, field));
-    }
-    if (column_index.min_values) {
-      column_index.min_values = column_index.min_values.map(min_value => decodeStatisticsValue(min_value, field));
+      return Promise.reject(new Error('No Column Index'));
     }
 
-    return column_index;
+    return this.read(+column.column_index_offset, column.column_index_length).then(data => {
+      let column_index = new parquet_thrift.ColumnIndex();
+      parquet_util.decodeThrift(column_index, data);
+      Object.defineProperty(column_index, 'column', { value: column });
+
+      // decode the statistics values
+      const field = this.schema.findField(column.meta_data.path_in_schema);
+      if (column_index.max_values) {
+        column_index.max_values = column_index.max_values.map(max_value => decodeStatisticsValue(max_value, field));
+      }
+      if (column_index.min_values) {
+        column_index.min_values = column_index.min_values.map(min_value => decodeStatisticsValue(min_value, field));
+      }
+
+      return column_index;
+    });
   }
 
-  async readPage(offsetIndex, pageNumber, records) {
+  readPage(offsetIndex, pageNumber, records) {
+    // TODO: faster than assign?
     let column = Object.assign({},offsetIndex.column);
     column.metadata = Object.assign({},column.metadata);
     column.meta_data.data_page_offset = offsetIndex.page_locations[pageNumber].offset;
     column.meta_data.total_compressed_size =  offsetIndex.page_locations[pageNumber].compressed_page_size;
-    const chunk = await this.readColumnChunk(this.schema, column);
-    Object.defineProperty(chunk,'column', {value: column});
-    let data = {
-      columnData: {[chunk.column.meta_data.path_in_schema.join(',')]: chunk},
-      rowCount: offsetIndex.page_locations.length
-    };
+    return this.readColumnChunk(this.schema, column).then(chunk => {
+      Object.defineProperty(chunk,'column', {value: column});
+      let data = {
+        columnData: {[chunk.column.meta_data.path_in_schema.join(',')]: chunk},
+        rowCount: offsetIndex.page_locations.length
+      };
 
-    return parquet_shredder.materializeRecords(this.schema, data, records);
+      return parquet_shredder.materializeRecords(this.schema, data, records);
+    });
   }
 
   async readRowGroup(schema, rowGroup, columnList) {
@@ -411,10 +421,12 @@ class ParquetEnvelopeReader {
     return buffer;
   }
 
-  async readColumnChunk(schema, colChunk) {
+  readColumnChunk(schema, colChunk) {
     if (colChunk.file_path !== null) {
-      throw 'external references are not supported';
+      return Promise.reject('external references are not supported');
     }
+
+    let dictionary = Promise.resolve();
 
     let field = schema.findField(colChunk.meta_data.path_in_schema);
     let type = parquet_util.getThriftEnum(
@@ -426,8 +438,7 @@ class ParquetEnvelopeReader {
         colChunk.meta_data.codec);
 
     let pagesOffset = +colChunk.meta_data.data_page_offset;
-    let pagesSize = +colChunk.meta_data.total_compressed_size;
-    let pagesBuf = await this.read(pagesOffset, Math.min(this.fileSize - pagesOffset, pagesSize));
+    let pagesSize = Math.min(this.fileSize - pagesOffset, +colChunk.meta_data.total_compressed_size);
 
     const opts = {
       type: type,
@@ -441,11 +452,13 @@ class ParquetEnvelopeReader {
     if (colChunk.meta_data.dictionary_page_offset) {
       const offset = +colChunk.meta_data.dictionary_page_offset;
       const size = Math.min(+this.fileSize - offset, this.default_dictionary_size);
-      const buffer = await this.read(offset,size);
-      opts.dictionary = decodePage({offset: 0, buffer, size: buffer.length}, opts).dictionary;
+      dictionary = this.read(offset,size).then(buffer => decodePage({offset: 0, buffer, size: buffer.length}, opts).dictionary);
     }
 
-    return decodePages(pagesBuf, opts);
+    return dictionary.then(dict => {
+      opts.dictionary = opts.dictionary || dict;
+      return this.read(pagesOffset, pagesSize).then(pagesBuf => decodePages(pagesBuf, opts));
+    });
   }
 
   async readFooter() {


### PR DESCRIPTION
Unfortunately aws lambda only supports Node 6 and async is not available.   If we use babel, async gets transpiled to `yield` which has terrible performance.