### PR TITLE
Patch PageLocation to be three element array that has getters/setters…

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -162,6 +162,19 @@ class ParquetReader {
         return o;
       };
 
+      // Go through all PageLocation objects and set the proper prototype
+      metadata.row_groups.forEach(rowGroup => {
+        rowGroup.columns.forEach(column => {
+          if (column.offsetIndex) {
+            column.offsetIndex.page_locations.forEach(d => {
+              if (Array.isArray(d)) {
+                Object.setPrototypeOf(d,parquet_thrift.PageLocation.prototype);
+              }
+            });
+          }
+        });
+      });
+
       convert(metadata);
     }
 
@@ -238,6 +251,10 @@ class ParquetReader {
 
   exportMetadata() {
     function replacer(key, value) {
+      if (value instanceof parquet_thrift.PageLocation) {
+        return [value[0], value[1], value[2]];
+      }
+
       if (typeof value === 'object') {
         for (let k in value) {
           if (value[k] instanceof Date) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 'use strict';
 const fs = require('fs');
 const thrift = require('thrift');
+const parquet_thrift = require('../gen-nodejs/parquet_types')
 
 
 /** We need to use a patched version of TFramedTransport where
@@ -17,6 +18,27 @@ class fixedTFramedTransport extends thrift.TFramedTransport {
     return (Buffer.from(str).equals(buffer)) ? str : buffer;
   }
 }
+
+
+/** Patch PageLocation to be three element array that has getters/setters
+  * for each of the properties (offset, compressed_page_size, first_row_index)
+  * This saves space considerably as we do not need to store the full variable
+  * names for every PageLocation
+  */
+
+const previousPageLocation = parquet_thrift.PageLocation.prototype;
+const PageLocation = parquet_thrift.PageLocation.prototype = [];
+PageLocation.write = previousPageLocation.write;
+PageLocation.read = previousPageLocation.read;
+
+const getterSetter = index => ({
+  get: function() { return this[index]; },
+  set: function(value) { return this[index] = value;}
+});
+
+Object.defineProperty(PageLocation,'offset', getterSetter(0));
+Object.defineProperty(PageLocation,'compressed_page_size', getterSetter(1));
+Object.defineProperty(PageLocation,'first_row_index', getterSetter(2));
 
 
 /**

--- a/test/metadata-cache.js
+++ b/test/metadata-cache.js
@@ -4,7 +4,7 @@ const assert = chai.assert;
 const path = require('path');
 const parquet = require('../parquet.js');
 
-describe('test-files', function() {  
+describe('metadata-cache', function() {  
   let metadata;
 
   before(async function() {


### PR DESCRIPTION
… for each of the properties (offset, compressed_page_size, first_row_index)

This saves space considerably as we do not need to store the full variable names for every PageLocation