### PR TITLE
External file

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -506,7 +506,7 @@ class ParquetEnvelopeReader {
     const offsetIndex = column.offsetIndex || await this.readOffsetIndex(column, null, opts);
     // TODO: faster than assign?
     column = Object.assign({},column);
-    column.metadata = Object.assign({},column.metadata);
+    column.meta_data = Object.assign({},column.meta_data);
     column.meta_data.data_page_offset = offsetIndex.page_locations[pageNumber].offset;
     column.meta_data.total_compressed_size =  offsetIndex.page_locations[pageNumber].compressed_page_size;
     const chunk = await this.readColumnChunk(this.schema, column);

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -125,12 +125,12 @@ class ParquetReader {
 
   static async openEnvelopeReader(envelopeReader, opts) {
     if (opts && opts.metadata) {
-      return new ParquetReader(opts.metadata, envelopeReader);
+      return new ParquetReader(opts.metadata, envelopeReader, opts);
     }
     try {
       await envelopeReader.readHeader();
       let metadata = await envelopeReader.readFooter();
-      return new ParquetReader(metadata, envelopeReader);
+      return new ParquetReader(metadata, envelopeReader, opts);
     } catch (err) {
       await envelopeReader.close();
       throw err;
@@ -143,7 +143,8 @@ class ParquetReader {
    * and internal use cases. Consider using one of the open{File,Buffer} methods
    * instead
    */
-  constructor(metadata, envelopeReader) {
+  constructor(metadata, envelopeReader, opts) {
+    opts = opts || {};
     if (metadata.version != PARQUET_VERSION) {
       throw 'invalid parquet version';
     }
@@ -185,7 +186,7 @@ class ParquetReader {
             this.metadata.schema.slice(1)));
 
     /* decode any statistics values */
-    if (this.metadata.row_groups && !this.metadata.json) {
+    if (this.metadata.row_groups && !this.metadata.json && !opts.rawStatistics) {
       this.metadata.row_groups.forEach(row => row.columns.forEach( col => {
         const stats = col.meta_data.statistics;
         if (stats) {

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -250,7 +250,7 @@ class ParquetReader {
     return md;
   }
 
-  exportMetadata() {
+  exportMetadata(indent) {
     function replacer(key, value) {
       if (value instanceof parquet_thrift.PageLocation) {
         return [value[0], value[1], value[2]];
@@ -281,7 +281,7 @@ class ParquetReader {
       }
     }
     const metadata = Object.assign({}, this.metadata, {json: true});
-    return JSON.stringify(metadata,replacer,2);
+    return JSON.stringify(metadata,replacer,indent);
   }
 
   /**

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -506,18 +506,25 @@ class ParquetEnvelopeReader {
     return data;
   }
 
-  async readPage(column, pageNumber, records, opts) {
-    const offsetIndex = column.offsetIndex || await this.readOffsetIndex(column, null, opts);
-    // TODO: faster than assign?
+  async readPage(column, page, records, opts) {
     column = Object.assign({},column);
     column.meta_data = Object.assign({},column.meta_data);
-    column.meta_data.data_page_offset = offsetIndex.page_locations[pageNumber].offset;
-    column.meta_data.total_compressed_size =  offsetIndex.page_locations[pageNumber].compressed_page_size;
+
+    if (page.offset !== undefined) {
+      if (isNaN(page.offset) || isNaN(page.compressed_page_size)) {
+        throw Error('page offset and/or size missing');
+      }
+      column.meta_data.data_page_offset = page.offset;
+      column.meta_data.total_compressed_size =  page.compressed_page_size;
+    } else {
+      const offsetIndex = column.offsetIndex || await this.readOffsetIndex(column, null, opts);
+      column.meta_data.data_page_offset = offsetIndex.page_locations[page].offset;
+      column.meta_data.total_compressed_size =  offsetIndex.page_locations[page].compressed_page_size;
+    }
     const chunk = await this.readColumnChunk(this.schema, column);
     Object.defineProperty(chunk,'column', {value: column});
     let data = {
-      columnData: {[chunk.column.meta_data.path_in_schema.join(',')]: chunk},
-      rowCount: offsetIndex.page_locations.length
+      columnData: {[chunk.column.meta_data.path_in_schema.join(',')]: chunk}
     };
 
     return parquet_shredder.materializeRecords(this.schema, data, records);
@@ -699,6 +706,7 @@ function decodePage(cursor, opts) {
 
 
 function decodePages(buffer, opts) {
+  opts = opts || {};
   let cursor = {
     buffer: buffer,
     offset: 0,

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -308,14 +308,28 @@ class ParquetEnvelopeReader {
     let fileStat = await parquet_util.fstat(filePath);
     let fileDescriptor = await parquet_util.fopen(filePath);
 
-    let readFn = parquet_util.fread.bind(undefined, fileDescriptor);
+    let readFn = (offset, length, file) => {
+      if (file) {
+        return Promise.reject('external references are not supported');
+      }
+
+      return  parquet_util.fread(fileDescriptor, offset, length);
+    };
+
     let closeFn = parquet_util.fclose.bind(undefined, fileDescriptor);
 
     return new ParquetEnvelopeReader(readFn, closeFn, fileStat.size, options);
   }
 
   static async openBuffer(buffer, options) {
-    let readFn = (offset, length) => buffer.slice(offset,offset+length);
+    let readFn = (offset, length, file) => {
+      if (file) {
+        return Promise.reject('external references are not supported');
+      }
+
+      return buffer.slice(offset,offset+length);
+    };
+
     let closeFn = () => ({});
     return new ParquetEnvelopeReader(readFn, closeFn, buffer.length, options);
   }
@@ -323,7 +337,11 @@ class ParquetEnvelopeReader {
   static async openS3(client, params, options) {
     let fileStat = async () => client.headObject(params).promise().then(d => d.ContentLength);
 
-    let readFn = async (offset, length) => {
+    let readFn = async (offset, length, file) => {
+      if (file) {
+        return Promise.reject('external references are not supported');
+      }
+
       let Range = `bytes=${offset}-${offset+length-1}`;
       let res = await client.getObject(Object.assign({Range}, params)).promise();
       return res.Body;
@@ -340,6 +358,9 @@ class ParquetEnvelopeReader {
     if (!params.url)
       throw new Error('URL missing');
 
+    let base = params.url.split('/');
+    base = base.slice(0, base.length-1).join('/')+'/';
+
     params.encoding = params.encoding || null;
 
     let defaultHeaders = params.headers || {};
@@ -353,10 +374,12 @@ class ParquetEnvelopeReader {
       req.on('error', reject);
     });
 
-    let readFn = (offset, length) => {
+    let readFn = (offset, length, file) => {
+      let url = file ? base+file : params.url;
+
       let range = `bytes=${offset}-${offset+length-1}`;
       let headers = Object.assign({}, defaultHeaders, {range});
-      let req = Object.assign({}, params, {headers});
+      let req = Object.assign({}, params, {headers, url});
       return new Promise( (resolve, reject) => {
         request(req, (err, res) => {
           if (err) {
@@ -386,8 +409,8 @@ class ParquetEnvelopeReader {
     }
   }
 
-  read(offset, length) {
-    return this.readFn(offset, length);
+  read(offset, length, file) {
+    return this.readFn(offset, length, file);
   }
 
   readHeader() {
@@ -515,7 +538,7 @@ class ParquetEnvelopeReader {
     return buffer;
   }
 
-  readColumnChunk(schema, colChunk) {
+  readColumnChunk(schema, colChunk, opts) {
     let dictionary = Promise.resolve();
 
     let field = schema.findField(colChunk.meta_data.path_in_schema);
@@ -528,26 +551,30 @@ class ParquetEnvelopeReader {
         colChunk.meta_data.codec);
 
     let pagesOffset = +colChunk.meta_data.data_page_offset;
-    let pagesSize = Math.min(this.fileSize - pagesOffset, +colChunk.meta_data.total_compressed_size);
+    let pagesSize = +colChunk.meta_data.total_compressed_size;
 
-    const opts = {
+    if (!colChunk.file_path) {
+      pagesSize = Math.min(this.fileSize - pagesOffset, +colChunk.meta_data.total_compressed_size);
+    }
+
+    opts = Object.assign({},opts, {
       type: type,
       rLevelMax: field.rLevelMax,
       dLevelMax: field.dLevelMax,
       compression: compression,
       column: field,
       num_values: colChunk.meta_data.num_values
-    };
+    });
 
     if (colChunk.meta_data.dictionary_page_offset) {
       const offset = +colChunk.meta_data.dictionary_page_offset;
       const size = Math.min(+this.fileSize - offset, this.default_dictionary_size);
-      dictionary = this.read(offset,size).then(buffer => decodePage({offset: 0, buffer, size: buffer.length}, opts).dictionary);
+      dictionary = this.read(offset, size, colChunk.file_path).then(buffer => decodePage({offset: 0, buffer, size: buffer.length}, opts).dictionary);
     }
 
     return dictionary.then(dict => {
       opts.dictionary = opts.dictionary || dict;
-      return this.read(pagesOffset, pagesSize).then(pagesBuf => decodePages(pagesBuf, opts));
+      return this.read(pagesOffset, pagesSize, colChunk.file_path).then(pagesBuf => decodePages(pagesBuf, opts));
     });
   }
 
@@ -614,34 +641,55 @@ function decodeStatistics(statistics, column) {
     statistics.max_value = decodeStatisticsValue(statistics.max_value, column);
   }
 
-  statistics.min = statistics.min_value;
-  statistics.max = statistics.max_value;
+  statistics.min = decodeStatisticsValue(statistics.min, column) || statistics.min_value;
+  statistics.max = decodeStatisticsValue(statistics.max, column) || statistics.max_value;
 
   return statistics;
 }
 
 function decodePage(cursor, opts) {
+  opts = opts || {};
+  let page;
   const pageHeader = new parquet_thrift.PageHeader();
-  cursor.offset += parquet_util.decodeThrift(pageHeader, cursor.buffer.slice(cursor.offset)); 
+
+  const headerOffset = cursor.offset;
+  const headerSize = parquet_util.decodeThrift(pageHeader, cursor.buffer.slice(cursor.offset)); 
+  cursor.offset += headerSize;
+
 
   const pageType = parquet_util.getThriftEnum(
       parquet_thrift.PageType,
       pageHeader.type);
 
+
   switch (pageType) {
     case 'DATA_PAGE':
-      pageHeader.data_page_header.statistics = decodeStatistics(pageHeader.data_page_header.statistics, opts.column);
-      return decodeDataPage(cursor, pageHeader, opts);
+      if (!opts.rawStatistics) {
+        pageHeader.data_page_header.statistics = decodeStatistics(pageHeader.data_page_header.statistics, opts.column);
+      }
+      page = decodeDataPage(cursor, pageHeader, opts);
+      break;
     case 'DATA_PAGE_V2':
-      pageHeader.data_page_header_v2.statistics = decodeStatistics(pageHeader.data_page_header_v2.statistics, opts.column);
-      return decodeDataPageV2(cursor, pageHeader, opts);
+      if (!opts.rawStatistics) {
+        pageHeader.data_page_header_v2.statistics = decodeStatistics(pageHeader.data_page_header_v2.statistics, opts.column);
+      }
+      page = decodeDataPageV2(cursor, pageHeader, opts);
+      break;
     case 'DICTIONARY_PAGE':
-      return {
+      page = {
         dictionary: decodeDictionaryPage(cursor, pageHeader, opts)
       };
+      break;
     default:
       throw `invalid page type: ${pageType}`;
   }
+
+
+  pageHeader.offset = headerOffset;
+  pageHeader.headerSize = headerSize;
+
+  page.pageHeader = pageHeader;
+  return page;
 }
 
 
@@ -656,6 +704,7 @@ function decodePages(buffer, opts) {
     rlevels: [],
     dlevels: [],
     values: [],
+    pageHeaders: [],
     count: 0
   };
 
@@ -680,6 +729,7 @@ function decodePages(buffer, opts) {
       }
     }
     data.count += pageData.count;
+    data.pageHeaders.push(pageData.pageHeader);
   }
 
   return data;

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -294,6 +294,10 @@ class ParquetReader {
     this.metadata = null;
   }
 
+  decodePages(buffer, opts) {
+    return decodePages(buffer,opts);
+  }
+
 }
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -41,6 +41,25 @@ Object.defineProperty(PageLocation,'compressed_page_size', getterSetter(1));
 Object.defineProperty(PageLocation,'first_row_index', getterSetter(2));
 
 
+exports.force32 = function() {
+  const protocol = thrift.TCompactProtocol.prototype;
+  protocol.zigzagToI64 = protocol.zigzagToI32;
+  protocol.readVarint64 = protocol.readVarint32 = function() {
+    let lo = 0;
+    let shift = 0;
+    let b;
+    while (true) {
+      b = this.trans.readByte();
+      lo = lo | ((b & 0x7f) << shift);
+      shift += 7;
+      if (!(b & 0x80)) {
+        break;
+      }
+    }
+    return lo;
+  };
+}
+
 /**
  * Helper function that serializes a thrift object into a buffer
  */

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -225,9 +225,10 @@ class ParquetEnvelopeWriter {
   /**
    * Write the columnIndices and offsetIndices
    */
-  writeIndex() {
+  writeIndex(_rowGroups) {
+    let rowGroups = _rowGroups || this.rowGroups;
     this.schema.fieldList.forEach( (c,i) => {
-      this.rowGroups.forEach(group => {
+      rowGroups.forEach(group => {
         let column = group.columns[i];
         if (!column) return;
 
@@ -716,6 +717,7 @@ function encodeFooter(schema, rowCount, rowGroups, userMetadata) {
 
     metadata.schema.push(schemaElem);
   }
+  console.log('metadata',metadata)
 
   let metadataEncoded = parquet_util.serializeThrift(metadata);
   let footerEncoded = new Buffer(metadataEncoded.length + 8);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -717,7 +717,6 @@ function encodeFooter(schema, rowCount, rowGroups, userMetadata) {
 
     metadata.schema.push(schemaElem);
   }
-  console.log('metadata',metadata)
 
   let metadataEncoded = parquet_util.serializeThrift(metadata);
   let footerEncoded = new Buffer(metadataEncoded.length + 8);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -226,9 +226,10 @@ class ParquetEnvelopeWriter {
    * Write the columnIndices and offsetIndices
    */
   writeIndex() {
-    this.rowGroups[0].columns.forEach( (c,i) => {
+    this.schema.fieldList.forEach( (c,i) => {
       this.rowGroups.forEach(group => {
         let column = group.columns[i];
+        if (!column) return;
 
         if (column.meta_data.columnIndex) {
           let columnBody = parquet_util.serializeThrift(column.meta_data.columnIndex);
@@ -252,13 +253,9 @@ class ParquetEnvelopeWriter {
   /**
    * Write the parquet file footer
    */
-  writeFooter(userMetadata) {
+  writeFooter(userMetadata, schema, rowCount, rowGroups) {
     if (!userMetadata) {
       userMetadata = {};
-    }
-
-    if (this.rowCount === 0) {
-      throw 'cannot write parquet file with zero rows';
     }
 
     if (this.schema.fieldList.length === 0) {

--- a/parquet.js
+++ b/parquet.js
@@ -2,6 +2,7 @@ const reader = require('./lib/reader');
 const writer = require('./lib/writer');
 const schema = require('./lib/schema');
 const shredder = require('./lib/shred');
+const util = require('./lib/util');
 
 module.exports = {
   ParquetEnvelopeReader: reader.ParquetEnvelopeReader,
@@ -10,5 +11,6 @@ module.exports = {
   ParquetWriter: writer.ParquetWriter,
   ParquetTransformer: writer.ParquetTransformer,
   ParquetSchema: schema.ParquetSchema,
-  ParquetShredder: shredder
+  ParquetShredder: shredder,
+  force32: util.force32
 };


### PR DESCRIPTION
* Allow reference to external files (http only to begin with)
* Expose a function that modifies thrift to do only 32 bit decoding
* Allow pageRead to take an offsetIndex element as a second argument
* Add option rawStatistics to make it easier to copy metadata over (without having to decode and reencode)
