### PR TITLE
close() is file descriptor specific so use end() instead.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -175,9 +175,9 @@ exports.oswrite = function(os, buf) {
   });
 }
 
-exports.osclose = function(os) {
+exports.osend = function(os) {
   return new Promise((resolve, reject) => {
-    os.close((err) => {
+    os.end((err) => {
       if (err) {
         reject(err);
       } else {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -174,7 +174,7 @@ class ParquetEnvelopeWriter {
    */
   static async openStream(schema, outputStream, opts) {
     let writeFn = parquet_util.oswrite.bind(undefined, outputStream);
-    let closeFn = parquet_util.osclose.bind(undefined, outputStream);
+    let closeFn = parquet_util.osend.bind(undefined, outputStream);
     return new ParquetEnvelopeWriter(schema, writeFn, closeFn, 0, opts);
   }
 


### PR DESCRIPTION
closes https://github.com/ZJONSSON/parquetjs/issues/22