### PR TITLE
Coerce values to numbers inside `new Date`

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -333,7 +333,7 @@ function toPrimitive_DATE(value) {
 }
 
 function fromPrimitive_DATE(value) {
-  return new Date(value * kMillisPerDay);
+  return new Date(+value * kMillisPerDay);
 }
 
 
@@ -355,7 +355,7 @@ function toPrimitive_TIMESTAMP_MILLIS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MILLIS(value) {
-  return new Date(value);
+  return new Date(+value);
 }
 
 function toPrimitive_TIMESTAMP_MICROS(value) {
@@ -376,7 +376,7 @@ function toPrimitive_TIMESTAMP_MICROS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MICROS(value) {
-  return new Date(value / 1000);
+  return new Date(+value / 1000);
 }
 
 function toPrimitive_INTERVAL(value) {


### PR DESCRIPTION
Files from [parquet-cpp](https://github.com/ZJONSSON/parquetjs/issues/24#issuecomment-414173367) lead file timestamps as strings.  Here we coerce the value to number to ensure the dates are correctly parsed.