### PR TITLE
improve transform error message

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -299,8 +299,14 @@ class ParquetTransformer extends stream.Transform {
 
   _transform(row, encoding, callback) {
     if (row) {
-      this.writer.appendRow(row)
-        .then(d => callback(null,d), callback);
+      this.writer.appendRow(row).then(
+        data => callback(null, data),
+        err => {
+          const fullErr = new Error(`Error transforming to parquet: ${err.toString()} row:${JSON.stringify(row)}`);
+          fullErr.origErr = err;
+          callback(fullErr);
+        }
+      );
     } else {
       callback();
     }


### PR DESCRIPTION
When a transform error occurs it can be difficult to determine
why it occurred so we improve the error by creating an
augmented error which includes:

 - description of what was occurring when error occurred
 - the original error message
 - the row that was attempting to be transformed
 - the original error attached as a property