### PR TITLE
Provide the readInt8 function call in plain_dictionary codec with arguments

### DIFF
--- a/lib/codec/plain_dictionary.js
+++ b/lib/codec/plain_dictionary.js
@@ -1,7 +1,7 @@
 const rle = require('./rle');
 
 exports.decodeValues = function(type, cursor, count, opts) {
-  opts.bitWidth = cursor.buffer.slice(cursor.offset, cursor.offset+1).readInt8();
+  opts.bitWidth = cursor.buffer.slice(cursor.offset, cursor.offset+1).readInt8(0);
   cursor.offset += 1;
   return rle.decodeValues(type, cursor, count, Object.assign({}, opts, {disableEnvelope: true}));
 };


### PR DESCRIPTION
In ```codec/plain_dictionary.js```, we are calling: ```readInt8()``` without argument:

>```js
>opts.bitWidth = cursor.buffer.slice(cursor.offset, cursor.offset+1).readInt8();
>```

This is fine for ```node.js```, because its ```readInt8()```method has a default argument of ```offset = 0```. See https://github.com/nodejs/node/blob/master/lib/internal/buffer.js#L411.

But when using this package in browser, it breaks because the buffer method (provided by shim packages) does not have such a default argument. For example: https://github.com/feross/buffer/blob/master/index.js#L1221

Accepting this change will make this package compatible to use in browser.