### PR TITLE
fromPrimitive_TIMESTAMP_MILLIS BigInt issue

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -354,7 +354,7 @@ function toPrimitive_TIMESTAMP_MILLIS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MILLIS(value) {
-  return new Date(+value);
+  return new Date(parseInt(value));
 }
 
 function toPrimitive_TIMESTAMP_MICROS(value) {


### PR DESCRIPTION
prevent fromPrimitive_TIMESTAMP_MILLIS from passing a BigInt to the Date constructor, which it does on Node 12