### PR TITLE
Fix for #58, fromPrimitive_TIMESTAMP_MICROS (TypeError when dividing a string by BigInt)

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -382,6 +382,9 @@ function toPrimitive_TIMESTAMP_MICROS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MICROS(value) {
+  if (value === undefined) {
+    return new Date(NaN);
+  }
   return new Date(parseInt(BigInt(value) / 1000n));
 }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -382,7 +382,7 @@ function toPrimitive_TIMESTAMP_MICROS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MICROS(value) {
-  return new Date(parseInt(value / 1000n));
+  return new Date(parseInt(BigInt(value) / 1000n));
 }
 
 function toPrimitive_INTERVAL(value) {


### PR DESCRIPTION
# Fix of `TypeError: Cannot mix BigInt and other types` for `fromPrimitive_TIMESTAMP_MICROS`

In `fromPrimitive_TIMESTAMP_MICROS(value: String): Date`, value (string) divided by `1000n` (BigInt), which causes `TypeError: Cannot mix BigInt and other types` in Node v12.19.1