### PR TITLE
Feature: Read from S3 using v3 of the aws js sdk - ParquetReader.openS3v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,21 +129,33 @@ let reader = await parquet.ParquetReader.openUrl(request,'https://domain/fruits.
 
 Parquet files can be read from an S3 object without having to download the whole file.
 You will have to supply the aws-sdk client as first argument and the bucket/key information 
-as second argument to the function `parquetReader.openS3`.
+as second argument to the function `parquetReader.openS3`. If using aws-sdk-js-v3, supply
+in order, an already constructed S3Client, an object containing the not yet constructed
+GetObjectCommand and HeadObjectCommand classes (with keys as shown; the command names
+in camel-case), and finally, supply the same params required for version 2 of sdk as the
+third argument to the function `parquetReader.openS3v3`.
 
 ``` js
+const params = {
+  Bucket: 'xxxxxxxxxxx',
+  Key: 'xxxxxxxxxxx'
+};
+// v2 example
 const AWS = require('aws-sdk');
 const client = new AWS.S3({
   accessKeyId: 'xxxxxxxxxxx',
   secretAccessKey: 'xxxxxxxxxxx'
 });
-
-const params = {
-  Bucket: 'xxxxxxxxxxx',
-  Key: 'xxxxxxxxxxx'
-};
-
 let reader = await parquet.ParquetReader.openS3(client,params);
+
+//v3 example
+const {S3Client, HeadObjectCommand, GetObjectCommand} = require('@aws-sdk/client-s3');
+const v3client = new S3Client({region:"us-east-1"});
+let commands = {
+    headObjectCommand: HeadObjectCommand,
+    getObjectCommand: GetObjectCommand
+};
+let v3reader = await parquet.ParquetReader.openS3v3(v3client, commands, params);
 ```
 
 ### Reading data from a buffer

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -103,6 +103,18 @@ class ParquetReader {
   }
 
   /**
+   * Open the parquet file from S3 using the supplied aws (v3) client, commands
+   * and params. The params have to include `Bucket` and `Key` to the file
+   * requested. This function returns a new parquet reader
+   */
+  static async openS3v3(client, commands, params, options) {
+    let envelopeReader = await ParquetEnvelopeReader.openS3v3(
+      client, commands, params, options
+    );
+    return this.openEnvelopeReader(envelopeReader, options);
+  }
+
+  /**
    * Open the parquet file from S3 using the supplied aws client and params
    * The params have to include `Bucket` and `Key` to the file requested
    * This function returns a new parquet reader
@@ -341,6 +353,59 @@ class ParquetEnvelopeReader {
 
     let closeFn = () => ({});
     return new ParquetEnvelopeReader(readFn, closeFn, buffer.length, options);
+  }
+
+  static async openS3v3(client, commands, params, options) {
+    return new Promise (async (resolve, reject) => {
+
+      let fileStat = async () => {
+        try {
+         let headObjectCommand = await client.send(
+           new commands.headObjectCommand (params)
+          );
+         return Promise.resolve(headObjectCommand.ContentLength);
+        }
+        catch (e){
+          return Promise.reject("rejected headObjectCommand: " + e.message);
+        }
+      }// fileStat
+
+      let bufferS3v3 = (incomingMessage) => {
+        return new Promise ((resolve, reject) => {
+          let body, data;
+          incomingMessage.on('readable', function() {
+            do{
+              if (data){
+                body = Buffer.concat([body, data]);
+              } else {
+                body = this.read() || body;
+              }
+            } while (data = this.read()); //do-while
+            resolve (body);
+          });//on 'readable' callback
+        });//Promise
+      };//bufferS3v3
+
+      let readFn = async (offset, length, file) => {
+        if (file) {
+          return Promise.reject('external references are not supported');
+        }
+        let range = `bytes=${offset}-${offset+length-1}`;
+        try {
+          let getObjectCommand = await client.send(
+            new commands.getObjectCommand({Range: range, ...params})
+          );
+          let body = await bufferS3v3 (getObjectCommand.Body);
+          return Promise.resolve(body);
+        }catch(e){
+          return Promise.reject("rejected getObject command " + e.message);
+        }
+      };//readFn
+
+      let closeFn = () => ({});
+
+      resolve (new ParquetEnvelopeReader(readFn, closeFn, fileStat, options));
+    });
   }
 
   static async openS3(client, params, options) {

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,6 +1,6 @@
 'use strict';
-const fs = require('fs');
-const thrift = require('thrift');
+//const fs = require('fs');
+//const thrift = require('thrift');
 const Int64 = require('node-int64');
 const parquet_thrift = require('../gen-nodejs/parquet_types')
 const parquet_shredder = require('./shred')
@@ -114,13 +114,13 @@ class ParquetReader {
 
   /**
    * Open the parquet file from a url using the supplied request module
-   * params should either be a string (url) or an object that includes 
-   * a `url` property.  
+   * params should either be a string (url) or an object that includes
+   * a `url` property.
    * This function returns a new parquet reader
    */
   static async openUrl(request, params, options) {
     let envelopeReader = await ParquetEnvelopeReader.openUrl(request, params, options);
-    return this.openEnvelopeReader(envelopeReader, options); 
+    return this.openEnvelopeReader(envelopeReader, options);
   }
 
   static async openEnvelopeReader(envelopeReader, opts) {
@@ -217,7 +217,7 @@ class ParquetReader {
     columnList = columnList.map((x) => x.constructor === Array ? x : [x]);
 
     return new ParquetCursor(
-        this.metadata, 
+        this.metadata,
         this.envelopeReader,
         this.schema,
         columnList);
@@ -270,7 +270,7 @@ class ParquetReader {
       if (typeof value === 'bigint') {
         return value.toString();
       }
-      
+
       if (value instanceof Int64) {
         if (isFinite(value)) {
           return Number(value);
@@ -639,7 +639,7 @@ function decodeStatisticsValue(value, column) {
     value = decodeValues(column.primitiveType,'PLAIN',{buffer: Buffer.from(value), offset: 0}, 1, column);
     if (value.length === 1) value = value[0];
   }
-  
+
   if (column.originalType) {
     value = parquet_types.fromPrimitive(column.originalType, value);
   }
@@ -669,7 +669,7 @@ function decodePage(cursor, opts) {
   const pageHeader = new parquet_thrift.PageHeader();
 
   const headerOffset = cursor.offset;
-  const headerSize = parquet_util.decodeThrift(pageHeader, cursor.buffer.slice(cursor.offset)); 
+  const headerSize = parquet_util.decodeThrift(pageHeader, cursor.buffer.slice(cursor.offset));
   cursor.offset += headerSize;
 
 
@@ -732,7 +732,7 @@ function decodePages(buffer, opts) {
       opts.dictionary = pageData.dictionary;
       continue;
     }
-   
+
     if (opts.dictionary) {
       pageData.values = pageData.values.map(d => opts.dictionary[d]);
     }
@@ -751,7 +751,7 @@ function decodePages(buffer, opts) {
 
   return data;
 }
- 
+
 function decodeDictionaryPage(cursor, header, opts) {
   const cursorEnd = cursor.offset + header.compressed_page_size;
 
@@ -801,7 +801,7 @@ function decodeDataPage(cursor, header, opts) {
   }
 
 
-  
+
   /* read repetition levels */
   let rLevelEncoding = parquet_util.getThriftEnum(
       parquet_thrift.Encoding,
@@ -835,7 +835,7 @@ function decodeDataPage(cursor, header, opts) {
   } else {
     dLevels.fill(0);
   }
- 
+
   /* read values */
   let valueCountNonNull = 0;
   for (let dlvl of dLevels) {
@@ -971,7 +971,7 @@ function decodeSchema(schemaElements) {
           /* define parent and num_children as non-enumerable */
           parent: {
             value: schema,
-            enumerable: false 
+            enumerable: false
           },
           num_children: {
             value: schemaElement.num_children,


### PR DESCRIPTION
Allow developers to use version 3 of the aws s3 client.  It follows in the spirit of parquetjs-lite to enable usage of the lighter version of the aws s3 sdk.  Pretty straightforward implementation.

There could be better interface/architectural approaches to the solution. Note, however, that the command inputs are readonly (also not modifiable by the middleware stacks) - hence the approach taken to pass the class modules themselves along with the input parameters as opposed to passing objects.  

The following is appended to the README, under the existing example, and is sharing that version's params variable.

`//v3 example`
`const {S3Client, HeadObjectCommand, GetObjectCommand} = require('@aws-sdk/client-s3');`
`const v3client = new S3Client({region:"us-east-1"});`
`let commands = {`
`    headObjectCommand: HeadObjectCommand,`
`    getObjectCommand: GetObjectCommand`
`};`
`let v3reader = await parquet.ParquetReader.openS3v3(v3client, commands, params);`