### PR TITLE
Add openS3 Compatibility for AWS SDK v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,21 +129,32 @@ let reader = await parquet.ParquetReader.openUrl(request,'https://domain/fruits.
 
 Parquet files can be read from an S3 object without having to download the whole file.
 You will have to supply the aws-sdk client as first argument and the bucket/key information 
-as second argument to the function `parquetReader.openS3`.
+as second argument to the function `parquetReader.openS3`. 
+
+If using version 3 of the aws-sdk for your S3 client, supply as the client argument an object
+containing an already constructed S3Client along with the plain HeadObjectCommand and 
+GetObjectCommand modules. 
 
 ``` js
+const params = {
+  Bucket: 'xxxxxxxxxxx',
+  Key: 'xxxxxxxxxxx'
+};
+// v2 example
 const AWS = require('aws-sdk');
 const client = new AWS.S3({
   accessKeyId: 'xxxxxxxxxxx',
   secretAccessKey: 'xxxxxxxxxxx'
 });
-
-const params = {
-  Bucket: 'xxxxxxxxxxx',
-  Key: 'xxxxxxxxxxx'
-};
-
 let reader = await parquet.ParquetReader.openS3(client,params);
+
+//v3 example
+const {S3Client, HeadObjectCommand, GetObjectCommand} = require('@aws-sdk/client-s3');
+const client = new S3Client({region:"us-east-1"});
+let reader = await parquet.ParquetReader.openS3(
+  {S3Client:client, HeadObjectCommand, GetObjectCommand},
+  params
+);
 ```
 
 ### Reading data from a buffer

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -11,7 +11,6 @@ const parquet_compression = require('./compression')
 const parquet_types = require('./types');
 const BufferReader = require('./bufferReader');
 
-
 /**
  * Parquet File Magic String
  */
@@ -59,9 +58,9 @@ class ParquetCursor  {
       }
 
       let rowBuffer = await this.envelopeReader.readRowGroup(
-          this.schema,
-          this.metadata.row_groups[this.rowGroupIndex],
-          this.columnList);
+        this.schema,
+        this.metadata.row_groups[this.rowGroupIndex],
+        this.columnList);
 
       this.rowGroup = parquet_shredder.materializeRecords(this.schema, rowBuffer);
       this.rowGroupIndex++;
@@ -103,14 +102,49 @@ class ParquetReader {
   }
 
   /**
-   * Open the parquet file from S3 using the supplied aws client and params
-   * The params have to include `Bucket` and `Key` to the file requested
-   * This function returns a new parquet reader
+   * Open the parquet file from S3 using the supplied aws client [,commands]
+   * and params. The params have to include `Bucket` and `Key` to the file
+   * requested. If using v3 of the aws sdk, combine the client and commands
+   * into an object with keys matching the original module names, and do not
+   * instantiate the commands; pass them as classes/modules. This function
+   * returns a new parquet reader or throws an Error.
    */
   static async openS3(client, params, options) {
-    let envelopeReader = await ParquetEnvelopeReader.openS3(client, params, options);
+    let envelopeReader;
+    /*
+     * sanity checks for client and params arguments
+     */
+    if (! client){
+      throw new Error("Missing S3 client object argument. Pass an instantiated "
+        + "AWS.S3 object (v2) or S3Client object (v3) from the AWS SDK."
+      );
+    }
+    // throw common error in case of null dereference, or missing property
+    try {
+      let {Key, Bucket} = params;
+      if (! Key || ! Bucket) throw "";
+    }catch (e){
+      throw new Error(
+        "Invalid params argument. Must be in the form {Key: 'x', Bucket: 'y'}."
+      );
+    }
+    /*
+     * determine which aws client should be assumed for envelopeReader (v2 | v3)
+     */
+    try {
+      if ('function' === typeof client.getObject){
+        // S3 client v2
+        envelopeReader = await ParquetEnvelopeReader.openS3(client, params, options);
+      }
+      else{ // S3 client v3
+        let {S3Client:c, HeadObjectCommand:h, GetObjectCommand:g} = client;
+        envelopeReader = await ParquetEnvelopeReader.openS3v3(c, h, g, params, options);
+      }
+    } catch (e){
+      throw new Error("Error accessing S3 bucket: " + e.message);
+    }
     return this.openEnvelopeReader(envelopeReader, options);
-  }
+  }//openS3
 
   /**
    * Open the parquet file from a url using the supplied request module
@@ -182,8 +216,8 @@ class ParquetReader {
     this.metadata = envelopeReader.metadata = metadata;
     this.envelopeReader = envelopeReader;
     this.schema = envelopeReader.schema = new parquet_schema.ParquetSchema(
-        decodeSchema(
-            this.metadata.schema.slice(1)));
+      decodeSchema(
+        this.metadata.schema.slice(1)));
 
     /* decode any statistics values */
     if (this.metadata.row_groups && !this.metadata.json && !opts.rawStatistics) {
@@ -217,10 +251,10 @@ class ParquetReader {
     columnList = columnList.map((x) => x.constructor === Array ? x : [x]);
 
     return new ParquetCursor(
-        this.metadata,
-        this.envelopeReader,
-        this.schema,
-        columnList);
+      this.metadata,
+      this.envelopeReader,
+      this.schema,
+      columnList);
   }
 
   /**
@@ -343,6 +377,53 @@ class ParquetEnvelopeReader {
     return new ParquetEnvelopeReader(readFn, closeFn, buffer.length, options);
   }
 
+  static async openS3v3(client, HeadObjectCommand, GetObjectCommand, params, options) {
+    let fileStat = async () => {
+      try {
+        let headObjectCommand = await client.send(new HeadObjectCommand (params));
+        return Promise.resolve(headObjectCommand.ContentLength);
+      }
+      catch (e){
+        // having params match command names makes e.message clear to user
+        return Promise.reject("rejected headObjectCommand: " + e.message);
+      }
+    }// fileStat
+
+    let readFn = async (offset, length, file) => {
+      if (file) {
+        return Promise.reject('external references are not supported');
+      }
+      let range = `bytes=${offset}-${offset+length-1}`;
+      try {
+        let getObjectCommand = await client.send(
+          new GetObjectCommand({Range: range, ...params})
+        );
+        let body = await (() => {
+          return new Promise ((resolve, reject) => {
+            let bodyBuffer, data;
+            getObjectCommand.Body.on('readable', function() {
+              do{
+                if (data){
+                  bodyBuffer = Buffer.concat([bodyBuffer, data]);
+                } else {
+                  bodyBuffer = this.read() || bodyBuffer;
+                }
+              } while (data = this.read()); //do-while
+              resolve (bodyBuffer);
+            });//on 'readable' callback
+          });//Promise
+        })();// body()
+        return Promise.resolve(body);
+      }catch(e){
+        return Promise.reject("rejected getObject command " + e.message);
+      }
+    };//readFn
+
+    let closeFn = () => ({});
+
+    return new ParquetEnvelopeReader(readFn, closeFn, fileStat, options);
+  }
+
   static async openS3(client, params, options) {
     let fileStat = async () => client.headObject(params).promise().then(d => d.ContentLength);
 
@@ -362,7 +443,7 @@ class ParquetEnvelopeReader {
   }
 
   static async openUrl(request, params, options) {
-     if (typeof params === 'string')
+    if (typeof params === 'string')
       params = {url: params};
     if (!params.url)
       throw new Error('URL missing');
@@ -439,7 +520,7 @@ class ParquetEnvelopeReader {
 
     if (typeof path === 'string') {
       if (!row_group) {
-       throw `Missing RowGroup ${row_group}`;
+        throw `Missing RowGroup ${row_group}`;
       }
       column = row_group.columns.find(d => d.meta_data.path_in_schema.join(',') === path);
       if (!column) {
@@ -559,12 +640,12 @@ class ParquetEnvelopeReader {
 
     let field = schema.findField(colChunk.meta_data.path_in_schema);
     let type = parquet_util.getThriftEnum(
-        parquet_thrift.Type,
-        colChunk.meta_data.type);
+      parquet_thrift.Type,
+      colChunk.meta_data.type);
 
     let compression = parquet_util.getThriftEnum(
-        parquet_thrift.CompressionCodec,
-        colChunk.meta_data.codec);
+      parquet_thrift.CompressionCodec,
+      colChunk.meta_data.codec);
 
     let pagesOffset = +colChunk.meta_data.data_page_offset;
     let pagesSize = +colChunk.meta_data.total_compressed_size;
@@ -674,8 +755,8 @@ function decodePage(cursor, opts) {
 
 
   const pageType = parquet_util.getThriftEnum(
-      parquet_thrift.PageType,
-      pageHeader.type);
+    parquet_thrift.PageType,
+    pageHeader.type);
 
 
   switch (pageType) {
@@ -765,8 +846,8 @@ function decodeDictionaryPage(cursor, header, opts) {
 
   if (opts.compression && opts.compression !== 'UNCOMPRESSED') {
     let valuesBuf = parquet_compression.inflate(
-        opts.compression,
-        dictCursor.buffer.slice(dictCursor.offset,cursorEnd));
+      opts.compression,
+      dictCursor.buffer.slice(dictCursor.offset,cursorEnd));
 
     dictCursor = {
       buffer: valuesBuf,
@@ -784,14 +865,14 @@ function decodeDataPage(cursor, header, opts) {
   const cursorEnd = cursor.offset + header.compressed_page_size;
   let valueCount = header.data_page_header.num_values;
   let valueEncoding = parquet_util.getThriftEnum(
-      parquet_thrift.Encoding,
-      header.data_page_header.encoding);
+    parquet_thrift.Encoding,
+    header.data_page_header.encoding);
 
   let valuesBufCursor = cursor;
   if (opts.compression && opts.compression !== 'UNCOMPRESSED') {
     let valuesBuf = parquet_compression.inflate(
-        opts.compression,
-        cursor.buffer.slice(cursor.offset, cursorEnd));
+      opts.compression,
+      cursor.buffer.slice(cursor.offset, cursorEnd));
 
     valuesBufCursor = {
       buffer: valuesBuf,
@@ -804,34 +885,34 @@ function decodeDataPage(cursor, header, opts) {
 
   /* read repetition levels */
   let rLevelEncoding = parquet_util.getThriftEnum(
-      parquet_thrift.Encoding,
-      header.data_page_header.repetition_level_encoding);
+    parquet_thrift.Encoding,
+    header.data_page_header.repetition_level_encoding);
 
   let rLevels = new Array(valueCount);
   if (opts.rLevelMax > 0) {
     rLevels = decodeValues(
-        PARQUET_RDLVL_TYPE,
-        rLevelEncoding,
-        valuesBufCursor,
-        valueCount,
-        { bitWidth: parquet_util.getBitWidth(opts.rLevelMax) });
+      PARQUET_RDLVL_TYPE,
+      rLevelEncoding,
+      valuesBufCursor,
+      valueCount,
+      { bitWidth: parquet_util.getBitWidth(opts.rLevelMax) });
   } else {
     rLevels.fill(0);
   }
 
   /* read definition levels */
   let dLevelEncoding = parquet_util.getThriftEnum(
-      parquet_thrift.Encoding,
-      header.data_page_header.definition_level_encoding);
+    parquet_thrift.Encoding,
+    header.data_page_header.definition_level_encoding);
 
   let dLevels = new Array(valueCount);
   if (opts.dLevelMax > 0) {
     dLevels = decodeValues(
-        PARQUET_RDLVL_TYPE,
-        dLevelEncoding,
-        valuesBufCursor,
-        valueCount,
-        { bitWidth: parquet_util.getBitWidth(opts.dLevelMax) });
+      PARQUET_RDLVL_TYPE,
+      dLevelEncoding,
+      valuesBufCursor,
+      valueCount,
+      { bitWidth: parquet_util.getBitWidth(opts.dLevelMax) });
   } else {
     dLevels.fill(0);
   }
@@ -846,15 +927,15 @@ function decodeDataPage(cursor, header, opts) {
 
 
   let values = decodeValues(
-      opts.type,
-      valueEncoding,
-      valuesBufCursor,
-      valueCountNonNull,
-      {
-        typeLength: opts.column.typeLength,
-        bitWidth: opts.column.typeLength,
-        disableEnvelope: opts.column.disableEnvelope
-      });
+    opts.type,
+    valueEncoding,
+    valuesBufCursor,
+    valueCountNonNull,
+    {
+      typeLength: opts.column.typeLength,
+      bitWidth: opts.column.typeLength,
+      disableEnvelope: opts.column.disableEnvelope
+    });
 
   cursor.offset = cursorEnd;
 
@@ -872,21 +953,21 @@ function decodeDataPageV2(cursor, header, opts) {
   const valueCount = header.data_page_header_v2.num_values;
   const valueCountNonNull = valueCount - header.data_page_header_v2.num_nulls;
   const valueEncoding = parquet_util.getThriftEnum(
-      parquet_thrift.Encoding,
-      header.data_page_header_v2.encoding);
+    parquet_thrift.Encoding,
+    header.data_page_header_v2.encoding);
 
   /* read repetition levels */
   let rLevels = new Array(valueCount);
   if (opts.rLevelMax > 0) {
     rLevels = decodeValues(
-        PARQUET_RDLVL_TYPE,
-        PARQUET_RDLVL_ENCODING,
-        cursor,
-        valueCount,
-        {
-          bitWidth: parquet_util.getBitWidth(opts.rLevelMax),
-          disableEnvelope: true
-        });
+      PARQUET_RDLVL_TYPE,
+      PARQUET_RDLVL_ENCODING,
+      cursor,
+      valueCount,
+      {
+        bitWidth: parquet_util.getBitWidth(opts.rLevelMax),
+        disableEnvelope: true
+      });
   } else {
     rLevels.fill(0);
   }
@@ -895,14 +976,14 @@ function decodeDataPageV2(cursor, header, opts) {
   let dLevels = new Array(valueCount);
   if (opts.dLevelMax > 0) {
     dLevels = decodeValues(
-        PARQUET_RDLVL_TYPE,
-        PARQUET_RDLVL_ENCODING,
-        cursor,
-        valueCount,
-        {
-          bitWidth: parquet_util.getBitWidth(opts.dLevelMax),
-          disableEnvelope: true
-        });
+      PARQUET_RDLVL_TYPE,
+      PARQUET_RDLVL_ENCODING,
+      cursor,
+      valueCount,
+      {
+        bitWidth: parquet_util.getBitWidth(opts.dLevelMax),
+        disableEnvelope: true
+      });
   } else {
     dLevels.fill(0);
   }
@@ -912,8 +993,8 @@ function decodeDataPageV2(cursor, header, opts) {
 
   if (header.data_page_header_v2.is_compressed) {
     let valuesBuf = parquet_compression.inflate(
-        opts.compression,
-        cursor.buffer.slice(cursor.offset, cursorEnd));
+      opts.compression,
+      cursor.buffer.slice(cursor.offset, cursorEnd));
 
     valuesBufCursor = {
       buffer: valuesBuf,
@@ -925,14 +1006,14 @@ function decodeDataPageV2(cursor, header, opts) {
   }
 
   let values = decodeValues(
-      opts.type,
-      valueEncoding,
-      valuesBufCursor,
-      valueCountNonNull,
-      {
-        typeLength: opts.column.typeLength,
-        bitWidth: opts.column.typeLength
-      });
+    opts.type,
+    valueEncoding,
+    valuesBufCursor,
+    valueCountNonNull,
+    {
+      typeLength: opts.column.typeLength,
+      bitWidth: opts.column.typeLength
+    });
 
   return {
     dlevels: dLevels,
@@ -947,8 +1028,8 @@ function decodeSchema(schemaElements) {
   schemaElements.forEach(schemaElement => {
 
     let repetitionType = parquet_util.getThriftEnum(
-        parquet_thrift.FieldRepetitionType,
-        schemaElement.repetition_type);
+      parquet_thrift.FieldRepetitionType,
+      schemaElement.repetition_type);
 
     let optional = false;
     let repeated = false;
@@ -983,13 +1064,13 @@ function decodeSchema(schemaElements) {
       schema = schema[schemaElement.name].fields;
     } else {
       let logicalType = parquet_util.getThriftEnum(
-          parquet_thrift.Type,
-          schemaElement.type);
+        parquet_thrift.Type,
+        schemaElement.type);
 
       if (schemaElement.converted_type != null) {
         logicalType = parquet_util.getThriftEnum(
-            parquet_thrift.ConvertedType,
-            schemaElement.converted_type);
+          parquet_thrift.ConvertedType,
+          schemaElement.converted_type);
       }
 
       schema[schemaElement.name] = {
@@ -1012,4 +1093,3 @@ module.exports = {
   ParquetEnvelopeReader,
   ParquetReader,
 };
-

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,6 +1,6 @@
 'use strict';
-const fs = require('fs');
-const thrift = require('thrift');
+//const fs = require('fs');
+//const thrift = require('thrift');
 const Int64 = require('node-int64');
 const parquet_thrift = require('../gen-nodejs/parquet_types')
 const parquet_shredder = require('./shred')
@@ -114,13 +114,13 @@ class ParquetReader {
 
   /**
    * Open the parquet file from a url using the supplied request module
-   * params should either be a string (url) or an object that includes 
-   * a `url` property.  
+   * params should either be a string (url) or an object that includes
+   * a `url` property.
    * This function returns a new parquet reader
    */
   static async openUrl(request, params, options) {
     let envelopeReader = await ParquetEnvelopeReader.openUrl(request, params, options);
-    return this.openEnvelopeReader(envelopeReader, options); 
+    return this.openEnvelopeReader(envelopeReader, options);
   }
 
   static async openEnvelopeReader(envelopeReader, opts) {
@@ -217,7 +217,7 @@ class ParquetReader {
     columnList = columnList.map((x) => x.constructor === Array ? x : [x]);
 
     return new ParquetCursor(
-        this.metadata, 
+        this.metadata,
         this.envelopeReader,
         this.schema,
         columnList);
@@ -270,7 +270,7 @@ class ParquetReader {
       if (typeof value === 'bigint') {
         return value.toString();
       }
-      
+
       if (value instanceof Int64) {
         if (isFinite(value)) {
           return Number(value);
@@ -639,7 +639,7 @@ function decodeStatisticsValue(value, column) {
     value = decodeValues(column.primitiveType,'PLAIN',{buffer: Buffer.from(value), offset: 0}, 1, column);
     if (value.length === 1) value = value[0];
   }
-  
+
   if (column.originalType) {
     value = parquet_types.fromPrimitive(column.originalType, value);
   }
@@ -669,7 +669,7 @@ function decodePage(cursor, opts) {
   const pageHeader = new parquet_thrift.PageHeader();
 
   const headerOffset = cursor.offset;
-  const headerSize = parquet_util.decodeThrift(pageHeader, cursor.buffer.slice(cursor.offset)); 
+  const headerSize = parquet_util.decodeThrift(pageHeader, cursor.buffer.slice(cursor.offset));
   cursor.offset += headerSize;
 
 
@@ -732,7 +732,7 @@ function decodePages(buffer, opts) {
       opts.dictionary = pageData.dictionary;
       continue;
     }
-   
+
     if (opts.dictionary) {
       pageData.values = pageData.values.map(d => opts.dictionary[d]);
     }
@@ -751,7 +751,7 @@ function decodePages(buffer, opts) {
 
   return data;
 }
- 
+
 function decodeDictionaryPage(cursor, header, opts) {
   const cursorEnd = cursor.offset + header.compressed_page_size;
 
@@ -801,7 +801,7 @@ function decodeDataPage(cursor, header, opts) {
   }
 
 
-  
+
   /* read repetition levels */
   let rLevelEncoding = parquet_util.getThriftEnum(
       parquet_thrift.Encoding,
@@ -835,7 +835,7 @@ function decodeDataPage(cursor, header, opts) {
   } else {
     dLevels.fill(0);
   }
- 
+
   /* read values */
   let valueCountNonNull = 0;
   for (let dlvl of dLevels) {
@@ -971,7 +971,7 @@ function decodeSchema(schemaElements) {
           /* define parent and num_children as non-enumerable */
           parent: {
             value: schema,
-            enumerable: false 
+            enumerable: false
           },
           num_children: {
             value: schemaElement.num_children,


### PR DESCRIPTION
Without changing parameter list for openS3 function, allows the function to take as input required arguments for use with version 3 of the AWS SDK S3 client (S3Client, HeadObjectCommand, and GetObjectCommand).  

Checks for existence of client.getObject (v2) in the client argument before attempting to destructure the client argument into an S3Client, HeadObjectCommand, and GetObjectCommand.  The actual implementation is abstracted down from the ParquetReader class (called by the developer) to the ParquetEnvelopeReader class (called by ParquetReader).

The S3Client should be an instantiated client object, and the commands should be passed in just as they are after being destructured/modularized from the require statement.  This allows for the ParquetEnvelopeReader class to set ranges on "getObject" calls for v3, as it does for v2 S3 clients (as command inputs are readonly in version 3 of the SDK and must be set per 'new' command).  It also allows the developer to set middleware on their client if they wish.

The following example was added to README.md

```
//v3 example
const {S3Client, HeadObjectCommand, GetObjectCommand} = require('@aws-sdk/client-s3');
const client = new S3Client({region:"us-east-1"});
let reader = await parquet.ParquetReader.openS3(
  {S3Client:client, HeadObjectCommand, GetObjectCommand},
  params
);
```