### PR TITLE
Fix for #58, fromPrimitive_TIMESTAMP_MICROS (TypeError when dividing a string by BigInt)

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -382,7 +382,13 @@ function toPrimitive_TIMESTAMP_MICROS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MICROS(value) {
-  return new Date(parseInt(value / 1000n));
+  if (value === undefined) {
+    return new Date(NaN);
+  } else if (typeof value === 'bigint') {
+    return new Date(parseInt(value / 1000n));
+  } else {
+    return new Date(value / 1000);
+  }
 }
 
 function toPrimitive_INTERVAL(value) {


### PR DESCRIPTION
I have a parquet file, which sometimes gives me bigint and sometimes int.

Taking into consideration fix in #59, created this PR