### PR TITLE
Simple select for array columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ columns should be read from disk. For example:
 ``` js
 // create a new cursor that will only return the `name` and `price` columns
 let cursor = reader.getCursor(['name', 'price']);
+
+// select a subset of array/struct columns using an array
+let cursor = reader.getCursor(
+  'name',
+  'price',
+  'array_column',
+  ['array_column', 'list', 'element', 'specific_field']
+);
 ```
 
 It is important that you call close() after you are finished reading the file to

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,7 +5,7 @@ const parquet_thrift = require('../gen-nodejs/parquet_types')
 
 
 /** We need to use a patched version of TFramedTransport where
-  * readString returns the original buffer instead of a string if the 
+  * readString returns the original buffer instead of a string if the
   * buffer can not be safely encoded as utf8 (see http://bit.ly/2GXeZEF)
   */
 
@@ -203,12 +203,12 @@ exports.osopen = function(path, opts) {
 
 exports.fieldIndexOf = function(arr, elem) {
   for (let j = 0; j < arr.length; ++j) {
-    if (arr[j].length !== elem.length) {
+    if (arr[j].length > elem.length) {
       continue;
     }
 
     let m = true;
-    for (let i = 0; i < elem.length; ++i) {
+    for (let i = 0; i < arr[j].length; ++i) {
       if (arr[j][i] !== elem[i]) {
         m = false;
         break;


### PR DESCRIPTION
I was trying to specify column names for columns of type "array" and no data was showing up.
```
let cursor = reader.getCursor([
  'array_column'
])
```
Upon investigation, the code was only checking for exact matches down to the individual fields in arrays, so the required code was 
```
let cursor = reader.getCursor([
  ['array_column', 'element', 'list', 'specific_field']
])
```
This wasn't documented, so I added it to the readme. 

I also added support for simply specifying
```
let cursor = reader.getCursor([
  'array_column'
])
```
which is more intuitive when you want all of the data in the array