### PR TITLE
Fix ParquetTransformer ERR_MULTIPLE_CALLBACK in Node.js v16

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -313,7 +313,7 @@ class ParquetTransformer extends stream.Transform {
   }
 
   _flush(callback) {
-    this.writer.close(callback)
+    this.writer.close()
       .then(d => callback(null, d), callback);
   }
 


### PR DESCRIPTION
ParquetTransformer _flush method calls the callback directly by passing it in as a parameter and then again calls it as the result to a promise. In earlier versions of Node.js this didn't appear to cause a problem even though technically it was wrong, but Node.js v16 now catches this problem and throws an ERR_MULTIPLE_CALLBACK. The solution is to simply not pass the callback in and only handle it from the promise (on resolve and reject).