### PR TITLE
Fix multiple callback calls

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -111,7 +111,7 @@ class ParquetWriter {
    * method twice on the same object or add any rows after the close() method has
    * been called
    */
-  async close(callback) {
+  async close() {
     if (this.closed) {
       throw 'writer was closed';
     }
@@ -128,10 +128,6 @@ class ParquetWriter {
     await this.envelopeWriter.writeFooter(this.userMetadata);
     await this.envelopeWriter.close();
     this.envelopeWriter = null;
-
-    if (callback) {
-      callback();
-    }
   }
 
   /**
@@ -313,7 +309,7 @@ class ParquetTransformer extends stream.Transform {
   }
 
   _flush(callback) {
-    this.writer.close(callback)
+    this.writer.close()
       .then(d => callback(null, d), callback);
   }
 


### PR DESCRIPTION
This library is incompatible with newer node versions (~16+) which throw an error when the callback is called more than once. The way this library currently works it is always going to call the callback within the `close` method and then in the `then` call afterwards resulting in

```
Error [ERR_MULTIPLE_CALLBACK]: Callback called multiple times
    at NodeError (node:internal/errors:400:5)
    at onFinish (node:internal/streams/writable:671:37)
    at node:internal/streams/transform:147:9
    at /app/node_modules/parquetjs-lite/lib/writer.js:321:18
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

In the process of testing this fix at the moment.. will report back.