### PR TITLE
Update types.js to fix BigInt mixing type error

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -382,6 +382,11 @@ function toPrimitive_TIMESTAMP_MICROS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MICROS(value) {
+  /* convert to BigInt if value is of different type */
+  if (!(value instanceof BigInt)) {
+    value = BigInt(value);
+  }
+
   return new Date(parseInt(value / 1000n));
 }
 


### PR DESCRIPTION
Fixing BigInt mixing type error:
"TypeError: Cannot mix BigInt and other types, use explicit conversions"